### PR TITLE
記事APIの階層をフラットに修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,12 +3,12 @@ class PostsController < ApplicationController
 
   def index
     @posts = Post.all.order(:id)
-    render json: @posts.as_json(include: :user)
+    render json: { posts: @posts.as_json(include: :user) }
   end
 
   def show
     @post = Post.find(params[:id])
-    render json: @post.as_json(include: %i[user certificate])
+    render json: { post: @post.as_json(include: %i[user certificate]) }
   end
 
   def create

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,12 +3,12 @@ class PostsController < ApplicationController
 
   def index
     @posts = Post.all.order(:id)
-    render json: { status: :success, posts: @posts.as_json(include: :user) }
+    render json: @posts.as_json(include: :user)
   end
 
   def show
     @post = Post.find(params[:id])
-    render json: { status: :success, post: @post.as_json(include: %i[user certificate]) }
+    render json: @post.as_json(include: %i[user certificate])
   end
 
   def create


### PR DESCRIPTION
## 実装内容
- 全記事取得APIのレスポンスデータの階層が浅くなるよう修正
- 上記を撤回し元に戻す。 