### PR TITLE
default.confを修正

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -24,6 +24,12 @@ server {
   error_page 404             /404.html;
   error_page 505 502 503 504 /500.html;
   try_files  $uri/index.html $uri @shikaku;
+
+  # / に対するハンドラを追加
+  location / {
+    try_files $uri $uri/ @shikaku;
+  }
+
   keepalive_timeout 5;
 
   # リバースプロキシ関連の設定


### PR DESCRIPTION
## 実装内容
- default.confにハンドラを追加（以下のChatGPTの答えを参照）

Nginxコンテナのログを見ると、ELB-HealthCheckerからのリクエストに対して404エラーが返されていることがわかります。これは、ECS上で実行されているElastic Load Balancer（ELB）が、定期的にヘルスチェックを実行しているためです。ELBはデフォルトでHTTP / 1.1のGETリクエストを送信し、200 OK応答を期待します。しかし、Nginxの設定ファイルには、/ に対するハンドラが定義されておらず、404が返されるため、ELBはサービスが利用できないと判断してコンテナを停止させています。

この問題を解決するには、Nginxの設定ファイルに/に対するハンドラを追加する必要があります。以下は、修正したNginxの設定ファイルです。