### PR TITLE
/直下のヘルスチェック用APIのルーティングを削除

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,5 +34,4 @@ Rails.application.routes.draw do
   resources :posts
   resources :sessions, only: [:create, :destroy]
   resources :certificates, only: [:index]
-  get '/', to: 'api/v1/alb#health_check'
 end


### PR DESCRIPTION
## 実装内容
- ルート直下のヘルスチェック用APIのルーティングを削除