### PR TITLE
VercelのURLをcors.rbに追加

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,7 +1,8 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins 'http://localhost:8000',
-            'http://localhost:3000'
+            'http://localhost:3000',
+            'https://shikaku.dev/'
 
     resource '*',
             headers: :any,


### PR DESCRIPTION
## 実装内容
- Vercelで購入した本番環境のドメインからアクセスできるようcors.rbに追加