### PR TITLE
ユーザー詳細APIと特定ユーザーに紐づく記事取得APIの作成

### DIFF
--- a/app/controllers/api/v1/follows_controller.rb
+++ b/app/controllers/api/v1/follows_controller.rb
@@ -1,3 +1,2 @@
 class Api::V1::FollowsController < ApplicationController
-  
 end

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -2,7 +2,11 @@ class Api::V1::PostsController < ApplicationController
   before_action :authenticate_api_v1_user!, only: %i[create update]
 
   def index
-    @posts = Post.all.order(:id)
+    @posts = if params[:user_id].nil?
+               Post.all.order(:id)
+             else
+               Post.find_by(user_id: params[:user_id])
+             end
     render json: { posts: @posts.as_json(include: :user) }
   end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,19 @@
+class Api::V1::UsersController < ApplicationController
+  before_action :authenticate_api_v1_user!, only: %i[show]
+
+  def show
+    # User.find(params[:id])では@userが存在しない場合にnilではなくエラーを発生させてしまう
+    @user = User.find_by(id: params[:id])
+    if @user
+      render json: { status: :success, user: @user }
+    else
+      render json: { status: 'error', message: 'ユーザーが見つかりませんでした' }
+    end
+  end
+
+  private
+
+  def user_params
+    params.permit(:id, :user_name, :email, :password, :password_confirmation, :profile)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,15 @@
 class UsersController < ApplicationController
   before_action :logged_in?, only: %i[update]
 
+  def show
+    @user = User.find(params[:id])
+    if @user
+      render json: { status: :success, user: @user }
+    else
+      render json: { status: 'error', message: @user.errors.full_messages.first }
+    end
+  end
+
   def create
     @user = User.new(user_params)
     if @user.save
@@ -23,6 +32,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.permit(:user_name, :email, :password, :password_confirmation)
+    params.permit(:id, :user_name, :email, :password, :password_confirmation)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       namespace :auth do
         resources :sessions, only: [:index]
       end
+      resources :users, only: [:show]
       resources :posts
       resources :certificates, only: [:index]
       resources :bookmarks, except: [:update]

--- a/spec/requests/api/v1/bookmarks_spec.rb
+++ b/spec/requests/api/v1/bookmarks_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-RSpec.describe "Api::V1::Bookmarks", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Api::V1::Bookmarks', type: :request do
+  describe 'GET /index' do
     let!(:user) { create(:user) }
     let!(:token) { sign_in user }
-    
+
     context 'ログイン済' do
       it 'ブックマークを全件取得する' do
         create_list(:bookmark, 3, user_id: user.id)
@@ -12,7 +12,7 @@ RSpec.describe "Api::V1::Bookmarks", type: :request do
         expect(response).to have_http_status(:ok)
         expect(JSON.parse(response.body)['bookmarks'].size).to eq(3)
       end
-      
+
       it 'ログインユーザーのブックマークを返す' do
         create_list(:bookmark, 3, user_id: user.id)
         get '/api/v1/bookmarks', headers: token
@@ -39,17 +39,17 @@ RSpec.describe "Api::V1::Bookmarks", type: :request do
 
     context 'ログイン済' do
       it 'ブックマークを作成する' do
-        expect {
+        expect do
           post '/api/v1/bookmarks', params: { user_id: user.id, post_id: new_post.id }, headers: token
-        }.to change(Bookmark, :count).by(1)
+        end.to change(Bookmark, :count).by(1)
         expect(response).to have_http_status(:ok)
         expect(JSON.parse(response.body)['status']).to eq('success')
       end
 
       it 'パラメータに誤りがある場合はブックマークの作成に失敗する' do
-        expect {
+        expect do
           post '/api/v1/bookmarks', params: { user_id: user.id, post_id: nil }, headers: token
-        }.not_to change(Bookmark, :count)
+        end.not_to change(Bookmark, :count)
         expect(response).to have_http_status(:ok)
         expect(JSON.parse(response.body)['status']).to eq('error')
       end
@@ -66,14 +66,14 @@ RSpec.describe "Api::V1::Bookmarks", type: :request do
   describe 'DELETE #destroy' do
     let!(:user) { create(:user) }
     let!(:new_post) { create(:post) }
-    let!(:bookmark) { create(:bookmark, user: user, post: new_post) }
+    let!(:bookmark) { create(:bookmark, user:, post: new_post) }
     let!(:token) { sign_in user }
 
     context 'ログイン済' do
       it 'ブックマークを外す' do
-        expect {
+        expect do
           delete "/api/v1/bookmarks/#{bookmark.id}", params: { user_id: user.id, post_id: new_post.id }, headers: token
-        }.to change(Bookmark, :count).by(-1)
+        end.to change(Bookmark, :count).by(-1)
         expect(response).to have_http_status(:ok)
         expect(JSON.parse(response.body)['status']).to eq('success')
       end
@@ -84,7 +84,6 @@ RSpec.describe "Api::V1::Bookmarks", type: :request do
         delete "/api/v1/bookmarks/#{bookmark.id}", params: { user_id: user.id, post_id: new_post.id }
         expect(response).to have_http_status(:unauthorized)
       end
-
     end
   end
 end

--- a/spec/requests/api/v1/certificates_spec.rb
+++ b/spec/requests/api/v1/certificates_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Api::V1::Certificates", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Api::V1::Certificates', type: :request do
+  describe 'GET /index' do
     let!(:certificate1) { create(:certificate) }
     let!(:certificate2) { create(:certificate) }
 

--- a/spec/requests/api/v1/posts_spec.rb
+++ b/spec/requests/api/v1/posts_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Api::V1::Posts", type: :request do
+RSpec.describe 'Api::V1::Posts', type: :request do
   describe 'GET #index' do
     let!(:user1) { create(:user) }
     let!(:user2) { create(:user) }
@@ -47,17 +47,17 @@ RSpec.describe "Api::V1::Posts", type: :request do
 
     context 'ログイン済' do
       it '記事を作成する' do
-        expect {
+        expect do
           post '/api/v1/posts', params: valid_params, headers: token
-        }.to change(Post, :count).by(1)
+        end.to change(Post, :count).by(1)
         expect(response).to have_http_status(:ok)
         expect(JSON.parse(response.body)['status']).to eq('success')
       end
 
       it 'パラメータに誤りがある場合は記事の作成に失敗する' do
-        expect {
+        expect do
           post '/api/v1/posts', params: { title: '' }, headers: token
-        }.not_to change(Post, :count)
+        end.not_to change(Post, :count)
         expect(response).to have_http_status(:ok)
         expect(JSON.parse(response.body)['status']).to eq('error')
       end
@@ -71,34 +71,33 @@ RSpec.describe "Api::V1::Posts", type: :request do
     end
   end
 
-  describe "PUT #update" do
+  describe 'PUT #update' do
     let!(:user) { create(:user) }
     let(:token) { sign_in user }
     let(:old_post) { create(:post, user_id: user.id) }
 
-    context "ログイン済" do
-      it "記事を更新する" do
-        put "/api/v1/posts/#{old_post.id}", params: { title: "New Title" }, headers: token
-        expect(old_post.reload.title).to eq("New Title")
+    context 'ログイン済' do
+      it '記事を更新する' do
+        put "/api/v1/posts/#{old_post.id}", params: { title: 'New Title' }, headers: token
+        expect(old_post.reload.title).to eq('New Title')
       end
 
-      it "ステータスコード200を返す" do
-        put "/api/v1/posts/#{old_post.id}", params: { title: "New Title" }, headers: token
+      it 'ステータスコード200を返す' do
+        put "/api/v1/posts/#{old_post.id}", params: { title: 'New Title' }, headers: token
         expect(response).to have_http_status(:success)
       end
     end
 
-    context "未ログイン" do
-      it "記事の更新に失敗する" do
-        put "/api/v1/posts/#{old_post.id}", params: { title: "New Title" }
-        expect(old_post.reload.title).to_not eq("New Title")
+    context '未ログイン' do
+      it '記事の更新に失敗する' do
+        put "/api/v1/posts/#{old_post.id}", params: { title: 'New Title' }
+        expect(old_post.reload.title).to_not eq('New Title')
       end
 
-      it "ログインを要求する" do
-        put "/api/v1/posts/#{old_post.id}", params: { title: "New Title" }
+      it 'ログインを要求する' do
+        put "/api/v1/posts/#{old_post.id}", params: { title: 'New Title' }
         expect(response).to have_http_status(:unauthorized)
       end
     end
-
   end
 end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Users', type: :request do
+  describe 'GET /show' do
+    let!(:user1) { create(:user, id: 1) }
+    let!(:user2) { create(:user, id: 2) }
+    let!(:token) { sign_in user1 }
+
+    context 'ログイン済' do
+      it '指定したユーザーが返ってくる' do
+        get "/api/v1/users/#{user2.id}", params: { id: user2.id }, headers: token
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['user']['id']).to eq(user2.id)
+      end
+
+      it '指定したユーザーが存在しない場合、エラーメッセージを返す' do
+        get '/api/v1/users/8', params: { id: 8 }, headers: token
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['message']).to eq('ユーザーが見つかりませんでした')
+      end
+    end
+
+    context '未ログイン' do
+      it 'ログインを要求する' do
+        get "/api/v1/users/#{user2.id}", params: { id: user2.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 実装内容
- 記事一覧取得APIに条件分岐を加え、特定のユーザーに紐づく記事を全て取得できるよう修正
- ユーザーの詳細ページ用のAPIを作成